### PR TITLE
Create basic encryption functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'pg', '~> 0.18'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
+gem 'attr_encrypted', '~> 3.0.3'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,11 +39,14 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
+    attr_encrypted (3.0.3)
+      encryptor (~> 3.0.0)
     builder (3.2.2)
     byebug (9.0.6)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    encryptor (3.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.14)
@@ -153,6 +156,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  attr_encrypted (~> 3.0.3)
   byebug
   listen (~> 3.0.5)
   pg (~> 0.18)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Passbank
 
 ## Encrypted password/message storage
+
+From the rails console:
+
+```ruby
+  # message creation
+  Message.create(name: "Max", password: "123", body: "Hello!")
+
+  # message retrieval
+  m = Message.find_by(name: "Max")
+  m.password = "123"
+  m.body #=> "Hello!"
+```

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,9 @@
+class Message < ApplicationRecord
+  attr_accessor :password
+
+  attr_encrypted(:body, key: :encryption_key)
+
+  def encryption_key
+    password + Rails.application.secrets.secret_key_base
+  end
+end

--- a/db/migrate/20161015185130_create_messages.rb
+++ b/db/migrate/20161015185130_create_messages.rb
@@ -1,0 +1,13 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :name
+      t.text :encrypted_body
+      t.text :encrypted_body_iv
+
+      t.timestamps
+    end
+
+    add_index :messages, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20161015185130) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "messages", force: :cascade do |t|
+    t.string   "name"
+    t.text     "encrypted_body"
+    t.text     "encrypted_body_iv"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.index ["name"], name: "index_messages_on_name", using: :btree
+  end
+
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Message, type: :model do
+  describe "encrypting a message" do
+    it "requires the correct password" do
+      message = Message.create(password: "something", body: "A secret")
+
+      expect do
+        message.password = "something else"
+        message.reload.body
+      end.to raise_error(OpenSSL::Cipher::CipherError)
+    end
+
+    it "allows the body to be read with the correct password set" do
+      message = Message.create(password: "master pass", body: "A secret")
+
+      message.reload
+      message.password = "master pass"
+
+      expect(message.body).to eq("A secret")
+    end
+  end
+end


### PR DESCRIPTION
- Messages have an encrypted body which could store sensitive
  information: e.g. username, password, diary entry
- The name field would be used for searching for specific messages
- This can now be used at the rails console:

``` ruby
 # message creation
 Message.create(name: "Max", password: "123", body: "Hello!")

 # message retrieval
 m = Message.find_by(name: "Max")
 m.password = "123"
 m.body #=> "Hello!"
```

Technical Details
- Encrypted messages use a password as a key for encryption
- This password is not stored anywhere so the database of passwords
  cannot be leaked
- It may not be wise incorporating the application secret_key_base as
  part of the encryption key since this allows short passwords to be
  used. This can be controlled by validations later. On the plus side,
  this is an extra layer of security.
- Using the `attr_encrypted` gem for encryption since it has good
  support and nice default behavior for ActiveRecord.
