### PR TITLE
Users can view messages through a web interface

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+FrozenStringLiteralComment:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ group :development do
 end
 
 group :development, :test do
+  gem "capybara-webkit"
+  gem "factory_girl_rails"
+  gem 'launchy'
   gem 'rspec-rails', '~> 3.5'
   gem 'bundler-audit'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (7.1.4)
     attr_encrypted (3.0.3)
       encryptor (~> 3.0.0)
@@ -46,16 +47,34 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.0.6)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     encryptor (3.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     ffi (1.9.14)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -154,6 +173,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -162,6 +183,9 @@ DEPENDENCIES
   attr_encrypted (~> 3.0.3)
   bundler-audit
   byebug
+  capybara-webkit
+  factory_girl_rails
+  launchy
   listen (~> 3.0.5)
   pg (~> 0.18)
   rails (~> 5.0.0, >= 5.0.0.1)
@@ -173,4 +197,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.13.4
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ From the rails console:
 ## Feature Wishlist
 * Validations around password absence/length
 * Better interface for setting/getting messages
-* Travis CI setup
 * Web interface for creating messages
 * Web interface for retrieving messages (search by name)
 * Deployment to heroku

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,4 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
-//= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/controllers/message_views_controller.rb
+++ b/app/controllers/message_views_controller.rb
@@ -1,0 +1,17 @@
+class MessageViewsController < ApplicationController
+  def new
+    @message = Message.find_by(name: params[:name])
+  end
+
+  def create
+    @message = Message.find_by(name: message_params[:name])
+    @message.password = message_params[:password]
+    render 'messages/show'
+  end
+
+  private
+
+  def message_params
+    params.require(:message_view).permit(:name, :password)
+  end
+end

--- a/app/views/message_views/new.html.erb
+++ b/app/views/message_views/new.html.erb
@@ -1,0 +1,7 @@
+<%= form_for :message_view, url: "/message_views" do |f| %>
+  <%= f.label :name %>:
+  <%= f.text_field :name %>
+  <%= f.label :password %>:
+  <%= f.text_field :password %>
+  <%= f.submit "View" %>
+<% end %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,0 +1,1 @@
+<%= @message.body %>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, message: :body]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :message_views, only: [:new, :create]
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :message do
+    password 'password'
+    body 'message'
+    name 'name'
+  end
+end

--- a/spec/features/user_views_message_body_spec.rb
+++ b/spec/features/user_views_message_body_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+feature 'User views message body' do
+  scenario 'password correct' do
+    create(:message, password: 'password', body: 'body', name: 'name')
+
+    visit new_message_view_path
+
+    fill_in 'Name', with: 'name'
+    fill_in 'Password', with: 'password'
+    click_button('View')
+
+    expect(page).to have_text('body')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,9 +7,13 @@ require 'rspec/rails'
 
 ActiveRecord::Migration.maintain_test_schema!
 
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |file| require file }
+
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end
+
+Capybara.javascript_driver = :webkit

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
* Currently messages can only be seeded, or created through the console.
However this allows an interface to retrieve them.
* A new resource `message_view` is created. One cannot retrieve message
bodies via a GET request for security reasons, otherwise `messages`
would be the only `resource` for this application. The security concerns
include GET request addresses being logged, so including a
password/encryption key in the query string params would be a poor
choice.
* Including the form on a messages index page was avoided since rails 5
has separate auth tokens for each form by default (or possibly for each
controller). This can be disabled in the config, but it seems a good
idea.
http://blog.bigbinary.com/2016/01/11/per-form-csrf-token-in-rails-5.html

Other:
* Introducing capybara-webkit for integration testing
* Filtering sensitive information from logs (password, message body)
* Including launchy gem since it is useful for debugging feature specs
(type save_and_open_page to open current test html page in a browser
tab)
* CI already setup so this line is removed from the README
* Factory girl was setup to make testing easy
* jquery-rails gem was already removed so one cant require jquery.
Therefor it is removed from the js manifest file `application.js`