### PR TITLE
Users can view message list and create new ones

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,14 @@
+class MessagesController < ApplicationController
+  def index
+    @messages = Message.all
+  end
+
+  def create
+    Message.create(message_params)
+    redirect_to messages_path
+  end
+
+  def message_params
+    params.require(:message).permit(:name, :body, :password)
+  end
+end

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,0 +1,15 @@
+<ul>
+  <% @messages.each do |message| %>
+    <li><%= link_to message.name, new_message_view_path %></li>
+  <% end %>
+</ul>
+
+<%= form_for :message, url: "/messages" do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :body %>
+  <%= f.text_field :body %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.submit %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
+  root to: 'messages#index'
+  resources :messages, only: [:index, :create]
   resources :message_views, only: [:new, :create]
 end

--- a/spec/features/user_creates_message_spec.rb
+++ b/spec/features/user_creates_message_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+feature 'User creates message' do
+  scenario 'valid attributes' do
+    visit messages_path
+
+    fill_in 'Name', with: 'message name'
+    fill_in 'Body', with: 'body'
+    fill_in 'Password', with: 'password'
+    click_button('Save Message')
+
+    expect(page).to have_text('message name')
+  end
+end


### PR DESCRIPTION
* Allow users to create new messages from the message index page
* The message index page displays a list of message names
* Messages in this list are links to the form that creates a message
view (allowing the user to see the message). A future commit will
probably populate the `name` field on the next form.
* Also roots to the message list index page

Practical Note:
* If this database is to be accessed through the web, messages will be
linked to users and require authentication. This would still be more
useful than storing things with plain text.

Handle later
* Styling
* Display helpful failure messages on save/fail
* Gracefully handle Cipher error
* Add length requirements for passwords